### PR TITLE
Feature #98: 게임 재시작 시 데이터 초기화, 스코어/사운드 bug fix

### DIFF
--- a/Assets/Scenes/MainStage1Scene.unity
+++ b/Assets/Scenes/MainStage1Scene.unity
@@ -5154,7 +5154,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backgroundMusic: {fileID: 8300000, guid: 03a68c518f3c744429d38362760688d9, type: 3}
-  musicVolume: 1
+  musicVolume: 0.2
   loop: 0
 --- !u!4 &2025449415
 Transform:

--- a/Assets/Scripts/ButtonHandler.cs
+++ b/Assets/Scripts/ButtonHandler.cs
@@ -20,13 +20,11 @@ public class ButtonHandler : MonoBehaviour
     public void LoadMainMenu()
     {
         GameManager.inst.LoadMainMenu();  // GameManager의 메서드 호출
-        GameManager.inst.ResetStats();
     }
 
     public void LoadStageSelection()
     {
         GameManager.inst.LoadStageSelection();
-        GameManager.inst.ResetStats();
     }
 
     public void LoadCharacterSelection(int stage)
@@ -46,7 +44,6 @@ public class ButtonHandler : MonoBehaviour
     }
     public void LoadMainStage()
     {
-        GameManager.inst.ResetStats();
         GameManager.inst.LoadMainStage();
     }
 

--- a/Assets/Scripts/ButtonHandler.cs
+++ b/Assets/Scripts/ButtonHandler.cs
@@ -20,11 +20,13 @@ public class ButtonHandler : MonoBehaviour
     public void LoadMainMenu()
     {
         GameManager.inst.LoadMainMenu();  // GameManager의 메서드 호출
+        GameManager.inst.ResetStats();
     }
 
     public void LoadStageSelection()
     {
         GameManager.inst.LoadStageSelection();
+        GameManager.inst.ResetStats();
     }
 
     public void LoadCharacterSelection(int stage)
@@ -44,6 +46,7 @@ public class ButtonHandler : MonoBehaviour
     }
     public void LoadMainStage()
     {
+        GameManager.inst.ResetStats();
         GameManager.inst.LoadMainStage();
     }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -69,6 +69,12 @@ public class GameManager : MonoBehaviour
         SceneManager.LoadScene("LeaderBoardScene");
     }
 
+    public void ResetStats()
+    {
+        life = maxLife;
+        score = 0;
+    }
+
     public string GetPlayerName()
     {
         return playerName;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -121,6 +121,7 @@ public class GameManager : MonoBehaviour
     public void AddScore(int _score)
     {
         score += _score;
+        if (score < 0) score = 0;
     }
     public int GetScore()
     {

--- a/Assets/Scripts/MainManager.cs
+++ b/Assets/Scripts/MainManager.cs
@@ -62,6 +62,7 @@ public class MainManager : MonoBehaviour
         characters[(int)GameManager.inst.GetCharacter()].SetActive(true);
         characterUI[(int)GameManager.inst.GetCharacter()].SetActive(true);
         Time.timeScale = 1;
+        GameManager.inst.ResetStats();
         isGameOver = false;
 
         characters[(int)GameManager.inst.GetCharacter()].GetComponent<PlayerControl>().ChangeColorOriginal();

--- a/Assets/Scripts/PlayerControl.cs
+++ b/Assets/Scripts/PlayerControl.cs
@@ -273,6 +273,11 @@ public class PlayerControl : MonoBehaviour
                 GameManager.inst.AddScore(1000); // 무적 상태에서 적 부딪하면 1000점 추가
                 return;
             }
+            
+            if (enemyCollisionSound != null)
+            {
+                AudioSource.PlayClipAtPoint(enemyCollisionSound, transform.position, coinVolume);
+            }
             GameManager.inst.RemoveLife();
             GameManager.inst.AddScore(-1000);
             StartCoroutine(Blink());
@@ -286,6 +291,7 @@ public class PlayerControl : MonoBehaviour
                 GameManager.inst.AddScore(500); // 무적 상태에서 장애물 부딪하면 500점 추가
                 return;
             }
+
             if (enemyCollisionSound != null)
             {
                 AudioSource.PlayClipAtPoint(enemyCollisionSound, transform.position, coinVolume);


### PR DESCRIPTION
closes #98 

- 게임 다시 시작 시 life, score 초기화
- 점수가 0점 미만으로 떨어지지 않도록 조치
- BGM 볼륨 1에서 0.2로 줄여서 다른 sound 잘 들리게 조치
- enemy 충돌시 소리가 안나던 bug fix