### PR TITLE
Feature #156: Boss Stage GameClear 시 DropObject 충돌하는 버그 해결

### DIFF
--- a/Assets/Scripts/Boss/BossStageManager.cs
+++ b/Assets/Scripts/Boss/BossStageManager.cs
@@ -186,8 +186,7 @@ public class BossStageManager : MonoBehaviour
         }
         gameClear.SetActive(true);
         isGameClear = true;
-        Cursor.lockState = CursorLockMode.None;
-        Cursor.visible = true;
+        GameManager.inst.CursorActive(true);
     }
 
     public void AddScoreBasedOnLives()

--- a/Assets/Scripts/Boss/BossStageManager.cs
+++ b/Assets/Scripts/Boss/BossStageManager.cs
@@ -115,6 +115,15 @@ public class BossStageManager : MonoBehaviour
             StartCoroutine(HandleBossDeath());
 
         }
+        //"Obstacle" 태그 오브젝트 비활성화
+        if (isGameClear) 
+        {
+            GameObject[] obstacleObjects = GameObject.FindGameObjectsWithTag("Obstacle");
+            foreach (GameObject obstacle in obstacleObjects)
+            {
+                obstacle.SetActive(false);
+            }
+        }
     }
 
     public void Pause()
@@ -144,17 +153,10 @@ public class BossStageManager : MonoBehaviour
         Time.timeScale = 0.2f;
         Time.fixedDeltaTime = 0.02f * Time.timeScale;
 
-        // 2. "Obstacle" 태그 오브젝트 비활성화
-        GameObject[] obstacleObjects = GameObject.FindGameObjectsWithTag("Obstacle");
-        foreach (GameObject obstacle in obstacleObjects)
-        {
-            obstacle.SetActive(false);
-        }
-
-        // 3. 보스의 죽음 애니메이션 실행
+        // 2. 보스의 죽음 애니메이션 실행
         bossControlScript.BossDeath();
 
-        // 4. 카메라가 보스 주위를 순회
+        // 3. 카메라가 보스 주위를 순회
         yield return StartCoroutine(cameraScript.OrbitAroundBoss());
 
         //(Optional)
@@ -166,17 +168,17 @@ public class BossStageManager : MonoBehaviour
             fires[i].SetActive(false);
 
         }
-        // 5. 플레이어가 제자리에서 한 바퀴 회전
+        // 4. 플레이어가 제자리에서 한 바퀴 회전
         Time.timeScale = 1f;
         Time.fixedDeltaTime = 0.02f;
         yield return StartCoroutine(playerScript.SpinInPlace());
 
 
-        // 6. 연출 후 카메라 원상복구+점수 추가
+        // 5. 연출 후 카메라 원상복구+점수 추가
         cameraScript.ResetCamera(); // 카메라를 원래 상태로 복구
         AddScoreBasedOnLives();
 
-        // 7. 승리 음악 재생
+        // 6. 승리 음악 재생
         if (musicManager != null)
         {
             musicManager.StopMusic();


### PR DESCRIPTION
closes #156

확인해보니 Coroutine 상에서 obstacle Inactivation을 하면 Coroutine이 기본적으로 여러 프레임에 걸쳐 실행되다보니 때때로 이미 생성된 오브젝트가 비활성화 되기 전에 플레이어에 충돌하는 문제가 있던 것 같습니다. 그래서 Update()으로 옮겨 매 frame마다 check하도록 했습니다.