### PR TITLE
Feature #241: Main에서 Boss로 넘어갈 때 캐릭터 색상 원상복구

### DIFF
--- a/Assets/Scenes/BossStage1Scene.unity
+++ b/Assets/Scenes/BossStage1Scene.unity
@@ -11637,7 +11637,6 @@ MonoBehaviour:
   - {fileID: 14207239}
   heartDeactivateSound: {fileID: 8300000, guid: 49b417a0f567648bbb81c12f25628f8e, type: 3}
   soundVolume: 0.7
-  isPausable: 1
   darkHearts:
   - {fileID: 2127547025}
   - {fileID: 1680471478}

--- a/Assets/Scenes/BossStage2Scene.unity
+++ b/Assets/Scenes/BossStage2Scene.unity
@@ -11493,7 +11493,6 @@ MonoBehaviour:
   - {fileID: 14207239}
   heartDeactivateSound: {fileID: 8300000, guid: 49b417a0f567648bbb81c12f25628f8e, type: 3}
   soundVolume: 0.7
-  isPausable: 1
   darkHearts:
   - {fileID: 2127547025}
   - {fileID: 1680471478}

--- a/Assets/Scenes/CharacterSelectionScene.unity
+++ b/Assets/Scenes/CharacterSelectionScene.unity
@@ -6349,6 +6349,7 @@ GameObject:
   - component: {fileID: 704526285}
   - component: {fileID: 704526284}
   - component: {fileID: 704526283}
+  - component: {fileID: 704526286}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -6422,6 +6423,39 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &704526286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 704526282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
 --- !u!1 &730748537
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/LeaderBoardScene.unity
+++ b/Assets/Scenes/LeaderBoardScene.unity
@@ -3247,6 +3247,7 @@ GameObject:
   - component: {fileID: 968080398}
   - component: {fileID: 968080397}
   - component: {fileID: 968080396}
+  - component: {fileID: 968080399}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -3320,6 +3321,39 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &968080399
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 968080395}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
 --- !u!1 &994947636
 GameObject:
   m_ObjectHideFlags: 0
@@ -7437,10 +7471,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c19ad06774dd347ae85f768223667c0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxLife: 3
-  bossStageMaxLife: 5
-  selected: 0
-  enemyKill: 0
 --- !u!4 &2131643267
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainMenuScene.unity
+++ b/Assets/Scenes/MainMenuScene.unity
@@ -964,6 +964,7 @@ GameObject:
   - component: {fileID: 968080398}
   - component: {fileID: 968080397}
   - component: {fileID: 968080396}
+  - component: {fileID: 968080399}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1037,6 +1038,39 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &968080399
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 968080395}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
 --- !u!1 &1268292820
 GameObject:
   m_ObjectHideFlags: 0
@@ -1611,9 +1645,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c19ad06774dd347ae85f768223667c0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxLife: 3
-  bossStageMaxLife: 5
-  selected: 0
 --- !u!4 &2131643267
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainStage1Scene.unity
+++ b/Assets/Scenes/MainStage1Scene.unity
@@ -5102,7 +5102,6 @@ MonoBehaviour:
   - {fileID: 798267248}
   heartDeactivateSound: {fileID: 8300000, guid: 49b417a0f567648bbb81c12f25628f8e, type: 3}
   soundVolume: 0.7
-  isPausable: 1
   stageDuration: 179
   boss: {fileID: 1913548026}
   bossLandingParticle: {fileID: 5797428246745224015, guid: 24fa55c4f1386e04ea2800527f88c4e1, type: 3}

--- a/Assets/Scenes/MainStage2Scene.unity
+++ b/Assets/Scenes/MainStage2Scene.unity
@@ -278,7 +278,6 @@ MonoBehaviour:
   - {fileID: 1883791994}
   heartDeactivateSound: {fileID: 8300000, guid: 49b417a0f567648bbb81c12f25628f8e, type: 3}
   soundVolume: 0.7
-  isPausable: 1
   stageDuration: 176
   boss: {fileID: 24506984}
   bossLandingParticle: {fileID: 5797428246745224015, guid: 24fa55c4f1386e04ea2800527f88c4e1, type: 3}

--- a/Assets/Scenes/StageSelectionScene.unity
+++ b/Assets/Scenes/StageSelectionScene.unity
@@ -892,6 +892,7 @@ GameObject:
   - component: {fileID: 693581950}
   - component: {fileID: 693581949}
   - component: {fileID: 693581948}
+  - component: {fileID: 693581951}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -965,6 +966,39 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &693581951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693581947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
 --- !u!1 &734565142
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Boss/BossStageManager.cs
+++ b/Assets/Scripts/Boss/BossStageManager.cs
@@ -54,6 +54,7 @@ public class BossStageManager : StageManager
     protected virtual void Start()
     {
         playerScript = activeCharacter.GetComponent<BossStagePlayer>();
+        playerScript.ChangeColorOriginal();
         base.isPausable = false;
 
         while (GameManager.inst.GetLife() < GameManager.inst.GetBossStageMaxLife())

--- a/Assets/Scripts/Main/MainStageManager.cs
+++ b/Assets/Scripts/Main/MainStageManager.cs
@@ -15,6 +15,7 @@ public class MainStageManager : StageManager
     public GameObject bossLandingParticle;
     float bossDropSpeed = 10f;
     protected MainStageTransitionManager transitionManager;
+    private MainStagePlayer playerScript;
 
     // Start is called before the first frame update
     protected override void Awake()
@@ -50,7 +51,7 @@ public class MainStageManager : StageManager
     public IEnumerator CompleteStage()
     {
         isPausable = false;
-        activeCharacter.GetComponent<MainStagePlayer>().SetEnableKeys(false);
+        playerScript.SetEnableKeys(false);
         isStageComplete = true;
 
         //boss = Instantiate(boss, new Vector3(0, 13, activeCharacter.transform.position.z + 3), Quaternion.Euler(0, 180, 0));
@@ -86,20 +87,21 @@ public class MainStageManager : StageManager
     {
         base.OnSceneLoaded(scene, mode);
         transitionManager.SetCurrentCharacter(activeCharacter);
-        activeCharacter.GetComponent<MainStagePlayer>().ChangeColorOriginal();
+        playerScript = activeCharacter.GetComponent<MainStagePlayer>();
+        playerScript.ChangeColorOriginal();
     }
 
     public override void PauseGame()
     {
         base.PauseGame();
-        activeCharacter.GetComponent<MainStagePlayer>().SetEnableKeys(false);
+        playerScript.SetEnableKeys(false);
         GameManager.inst.CursorActive(true);
     }
 
     public override void ResumeGame()
     {
         base.ResumeGame();
-        activeCharacter.GetComponent<MainStagePlayer>().SetEnableKeys(true);
+        playerScript.SetEnableKeys(true);
         GameManager.inst.CursorActive(false);
     }
 
@@ -107,7 +109,7 @@ public class MainStageManager : StageManager
     protected override void HandleGameOver()
     {
         base.HandleGameOver();
-        activeCharacter.GetComponent<MainStagePlayer>().SetEnableKeys(false);
+        playerScript.SetEnableKeys(false);
         GameManager.inst.CursorActive(true);
     }
     public IEnumerator AddScoreEverySecond()

--- a/Assets/Scripts/Main/MainStageManager.cs
+++ b/Assets/Scripts/Main/MainStageManager.cs
@@ -52,6 +52,7 @@ public class MainStageManager : StageManager
     {
         isPausable = false;
         playerScript.SetEnableKeys(false);
+        playerScript.ChangeColorOriginal();
         isStageComplete = true;
 
         //boss = Instantiate(boss, new Vector3(0, 13, activeCharacter.transform.position.z + 3), Quaternion.Euler(0, 180, 0));

--- a/Assets/Scripts/Main/MainStageManager.cs
+++ b/Assets/Scripts/Main/MainStageManager.cs
@@ -52,7 +52,12 @@ public class MainStageManager : StageManager
     {
         isPausable = false;
         playerScript.SetEnableKeys(false);
+
+        // disable invincible color change
+        playerScript.invincibleLength = 0f;
+        playerScript.SetIsInvincible(false);
         playerScript.ChangeColorOriginal();
+
         isStageComplete = true;
 
         //boss = Instantiate(boss, new Vector3(0, 13, activeCharacter.transform.position.z + 3), Quaternion.Euler(0, 180, 0));


### PR DESCRIPTION
### 추가 사항
- #239 에서 스크립트의 몇몇 variable이 public에서 private으로 변경되면서, inspector에서 조작가능한 변수가 줄었음. 이에 따라 scene 파일에도 해당하는 변경사항을 적용해줬음. (방법: scene 띄워놓고 아무거나 체크박스 2번 눌러서 원래 상태로 돌려두고 scene 저장하면 반영됨)